### PR TITLE
Adding support for Safari 9 pinned tab favicon

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="/css/fontes/css/fontello.css">
 <link href='http://fonts.googleapis.com/css?family=News+Cycle:400,700' rel='stylesheet' type='text/css'>
 <link rel="shortcut icon" href="/img/icon.jpg">
+<link rel="mask-icon" href="/img/favicon.jpg" color="black">
 <link rel="author" href="fabricioronchi.com">
 <meta name="description" content="AngularJS, Javascript, HTML5, CSS3, Ruby, Phonegap, Java..."></head>
 {% include googleanalytics.html %}


### PR DESCRIPTION
:octocat: 
